### PR TITLE
Windows-compatibility: Thumbnail generation (Compound Solution Pack)

### DIFF
--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -288,9 +288,7 @@ function islandora_compound_object_update_parent_thumbnail($parent) {
     $child = islandora_object_load($parts[0]);
     $mime_detector = new MimeDetect();
     $ext = $mime_detector->getExtension($child['TN']->mimeType);
-    // slangerx: For some reason, complex syntax {$...} sometimes doesn't get
-    // processed, causing error messages like: "The file {$child->id}_TN.{$ext}
-    // cannot be found." Concatenating the variables seemed to fix this problem.
+    // slangerx: Concatenate the variables (rather than using complex syntax).
     $file = drupal_realpath('temporary://' . $child->id . '_TN.' . $ext);
     $child['TN']->getContent($file);
     if (empty($parent['TN'])) {

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -288,7 +288,7 @@ function islandora_compound_object_update_parent_thumbnail($parent) {
     $child = islandora_object_load($parts[0]);
     $mime_detector = new MimeDetect();
     $ext = $mime_detector->getExtension($child['TN']->mimeType);
-    // slangerx: Concatenate the path (rather than using complex syntax).
+    // slangerx: Concatenate the path, rather than using complex syntax.
     $file = drupal_realpath('temporary://' . $child->id . '_TN.' . $ext);
     $child['TN']->getContent($file);
     if (empty($parent['TN'])) {

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -288,7 +288,7 @@ function islandora_compound_object_update_parent_thumbnail($parent) {
     $child = islandora_object_load($parts[0]);
     $mime_detector = new MimeDetect();
     $ext = $mime_detector->getExtension($child['TN']->mimeType);
-    // slangerx: Concatenate the variables (rather than using complex syntax).
+    // slangerx: Concatenate the path (rather than using complex syntax).
     $file = drupal_realpath('temporary://' . $child->id . '_TN.' . $ext);
     $child['TN']->getContent($file);
     if (empty($parent['TN'])) {

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -283,13 +283,17 @@ function islandora_compound_object_access(AbstractObject $object) {
  * Replaces parent object thumbnail with child's thumbnail.
  */
 function islandora_compound_object_update_parent_thumbnail($parent) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
   $parts = islandora_compound_object_get_parts($parent->id);
   if (!empty($parts)) {
     $child = islandora_object_load($parts[0]);
     $mime_detector = new MimeDetect();
     $ext = $mime_detector->getExtension($child['TN']->mimeType);
-    // slangerx: Concatenate the path, rather than using complex syntax.
-    $file = drupal_realpath('temporary://' . $child->id . '_TN.' . $ext);
+    // Windows will likely store temp data in a temp directory
+    // rather than in memory. Since the colon is forbidden in
+    // filenames, replace it with an underscore instead.
+    $thumbnail_id = ((islandora_deployed_on_windows()) ? str_replace(':', '_', $child->id) : $child->id);
+    $file = drupal_realpath("temporary://{$thumbnail_id}_TN.{$ext}");
     $child['TN']->getContent($file);
     if (empty($parent['TN'])) {
       $ds = $parent->constructDatastream('TN', 'M');

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -289,7 +289,7 @@ function islandora_compound_object_update_parent_thumbnail($parent) {
     $mime_detector = new MimeDetect();
     $ext = $mime_detector->getExtension($child['TN']->mimeType);
     // slangerx: For some reason, complex syntax {$...} sometimes doesn't get
-    // processed, resulting in error messages like: "The file {$child->id}_TN.{$ext}
+    // processed, causing error messages like: "The file {$child->id}_TN.{$ext}
     // cannot be found." Concatenating the variables seemed to fix this problem.
     $file = drupal_realpath('temporary://' . $child->id . '_TN.' . $ext);
     $child['TN']->getContent($file);

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -288,7 +288,10 @@ function islandora_compound_object_update_parent_thumbnail($parent) {
     $child = islandora_object_load($parts[0]);
     $mime_detector = new MimeDetect();
     $ext = $mime_detector->getExtension($child['TN']->mimeType);
-    $file = drupal_realpath('temporary://{$child->id}_TN.{$ext}');
+    // slangerx: For some reason, complex syntax {$...} sometimes doesn't get
+    // processed, resulting in error messages like: "The file {$child->id}_TN.{$ext}
+    // cannot be found." Concatenating the variables seemed to fix this problem.
+    $file = drupal_realpath('temporary://' . $child->id . '_TN.' . $ext);
     $child['TN']->getContent($file);
     if (empty($parent['TN'])) {
       $ds = $parent->constructDatastream('TN', 'M');


### PR DESCRIPTION
Some Windows-incompatibilities have crept into the Islandora codebase ([additional background can be found here](https://groups.google.com/d/msg/islandora/0MAhLDjbago/9knbOynlyIcJ)).

Windows will sometimes write temporary data to a temp directory rather than to straight memory (this was a [necessary change to the Tuque library](https://github.com/Islandora/tuque/pull/83)). As a result, the code that generates the thumbnail needs to be updated in two ways:
-  **Thumbnail name:** The colon in the object ID needs to be replaced with an underscore in the filename, since the [colon is a forbidden character in Windows paths](http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx#naming_conventions). Using it results in the following error: `Warning: filesize(): stat failed for <PATH TO TEMP DIRECTORY>/islandora:XX_TN.jpg in CurlConnection->putRequest()`
- **Double-quotes:** The path `temporary://{$child->id}_TN.{$ext}` only works when it is enclosed in double-quotes. When single-quotes are used, the variables aren't interpreted, resulting in the error: `The file {$child->id}_TN.{$ext} cannot be found.` [[Reference](http://stackoverflow.com/a/14046850)]

_NOTE 1:_ The [Islandora Paged Content module](https://github.com/Islandora/islandora_paged_content/pull/42) is experiencing the same problem.
_NOTE 2:_ The function _islandora_deployed_on_windows()_ is introduced here: https://github.com/Islandora/islandora/pull/450
