### PR TITLE
Consider the case when the child is missing a thumbnail.

### DIFF
--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -272,6 +272,10 @@ function islandora_compound_object_update_parent_thumbnail($parent) {
   $parts = islandora_compound_object_get_parts($parent->id);
   if (!empty($parts)) {
     $child = islandora_object_load($parts[0]);
+    // Child doesn't have a thumbnail then we can't set the parents TN either.
+    if (empty($child['TN'])) {
+      return;
+    }
     $mime_detector = new MimeDetect();
     $ext = $mime_detector->getExtension($child['TN']->mimeType);
     // Windows will likely store temp data in a temp directory


### PR DESCRIPTION
Catches the case where an object exists as the first child of a compound but does not have a Thumbnail.
