### PR TITLE
Extra height CSS attribute.

### DIFF
--- a/css/islandora_compound_object.jail_block.css
+++ b/css/islandora_compound_object.jail_block.css
@@ -1,7 +1,6 @@
 /* Display in Content Region */
 
 #block-islandora-compound-object-compound-jail-display {
-    height: 100px;
     height: 200px;
     width: 100%;
     overflow-x: hidden;


### PR DESCRIPTION
Tested the page prior to the change in Firefox 38.0.5, Chrome 43.0.2357.130 (64-bit), and Safari 6.2.6 (8537.85.15.3).

They all displayed the div as 200px high. If someone wants to check IE first, that's fine by me.
