### PR TITLE
Unify autocomplete queries

### DIFF
--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -319,8 +319,8 @@ function islandora_compound_object_autocomplete($string, $parent = FALSE) {
   // - https://www.w3.org/TR/xmlschema-2/#dt-metac and
   // - https://www.w3.org/TR/xmlschema-2/#dt-cces1
   $meta = array(
-    '.',
     '\\',
+    '.',
     '?',
     '*',
     '+',
@@ -335,7 +335,7 @@ function islandora_compound_object_autocomplete($string, $parent = FALSE) {
     '^',
   );
   $escape_meta = function ($meta) {
-    return "\\$meta";
+    return "\\\\$meta";
   };
   $meta_replacements = drupal_map_assoc($meta, $escape_meta);
 

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -305,48 +305,67 @@ function islandora_compound_object_update_parent_thumbnail($parent) {
 /**
  * Autocomplete callback for child object search.
  *
- * @string string $string
+ * @param string $string
  *   The user supplied string that is being searched for.
+ * @param bool $parent
+ *   A flag indicating if we are to return objects usable as parents.
  */
 function islandora_compound_object_autocomplete($string, $parent = FALSE) {
   $matches = array();
   $islandora_tuque = islandora_get_tuque_connection();
   $compound_enforcement = variable_get('islandora_compound_object_compound_children', TRUE);
 
+  // Build escapes as per:
+  // - https://www.w3.org/TR/xmlschema-2/#dt-metac and
+  // - https://www.w3.org/TR/xmlschema-2/#dt-cces1
+  $meta = array(
+    '.',
+    '\\',
+    '?',
+    '*',
+    '+',
+    '{',
+    '}',
+    '(',
+    ')',
+    '[',
+    ']',
+    '|',
+    '-',
+    '^',
+  );
+  $escape_meta = function ($meta) {
+    return "\\$meta";
+  };
+  $meta_replacements = drupal_map_assoc($meta, $escape_meta);
+
+  $replacements = array(
+    '!compound_model' => '?model',
+    '!text' => str_replace(array_keys($meta_replacements), $meta_replacements, $string),
+  );
   if ($compound_enforcement && $parent) {
     $compound_model = ISLANDORA_COMPOUND_OBJECT_CMODEL;
-    $parent_query = <<<EOQ
-SELECT ?pid ?title FROM <#ri>
-WHERE {
-  ?pid <fedora-model:hasModel> <info:fedora/$compound_model> ;
-       <fedora-model:label> ?title
-}
-EOQ;
-    $results = $islandora_tuque->repository->ri->sparqlQuery($parent_query, 'unlimited');
-  }
-  else {
-    $results = $islandora_tuque->api->a->findObjects('terms', '*' . $string . '*', 10);
+    $replacements['!compound_model'] = "<info:fedora/$compound_model>";
   }
 
-  // Need to parse results differently for the SPARQL query versus findObjects.
-  if ($compound_enforcement && $parent) {
-    foreach ($results as $result) {
-      if (strpos(drupal_strtoupper($result['title']['value']), drupal_strtoupper($string)) !== FALSE) {
-        $matches[$result['pid']['value']] = $result['title']['value'] . ' (' . $result['pid']['value'] . ')';
-      }
-    }
-  }
-  else {
-    foreach ($results['results'] as $result) {
-      // Empty array elements getting sent through.
-      if (is_array($result['title'])) {
-        $title = $result['title'][0];
-      }
-      else {
-        $title = $result['title'];
-      }
-      $matches[$result['pid']] = $title . ' (' . $result['pid'] . ')';
-    }
+  $query = <<<'EOQ'
+SELECT DISTINCT ?pid ?title
+FROM <#ri>
+WHERE {
+  ?pid <fedora-model:hasModel> !compound_model ;
+       <fedora-model:label> ?title .
+  FILTER(regex(?title, "!text", 'i') || regex(str(?pid), "!text", 'i'))
+}
+LIMIT 10
+EOQ;
+  $query = format_string($query, $replacements);
+  $results = $islandora_tuque->repository->ri->sparqlQuery($query, 'unlimited');
+
+  foreach ($results as $result) {
+    $matches[$result['pid']['value']] = t('!title (!pid)', array(
+      '!title' => $result['title']['value'],
+      '!pid' => $result['pid']['value'],
+    ));
   }
   drupal_json_output($matches);
 }


### PR DESCRIPTION
**Jira:** [ISLANDORA-1586](https://jira.duraspace.org/browse/ISLANDORA-1586) 
# What does this Pull Request do?

Avoid querying different endpoints at different types, to avoid multiple similar result parsing implementation.
# How should this be tested?

In the `islandora/object/{pid}/manage/compound` route:
- With "Only allow compound objects to have child objects associated with them" disabled at `admin/islandora/solution_pack_config/compound_object`:
  - On any object, children and parents can be autocompleted to any object.
- Enabled:
  - Any object can autocomplete objects with the "islandora:compoundCModel" as parent objects
  - "islandora:compoundCModel" objects can autocomplete any object as children
# Background context:

Had a chat with @mitchmac regarding the original intent of the query here: It was to be able to autocomplete using either titles or PIDs. At the time of the original implementation, we were not using Sparql to the degree we are today (still preferring itql, IIRC?). Had thought about making allowing it to query _any_ field on objects (being unsure across which fields exactly "terms" would query); however, that might lead to confusion when the match occurs on something other than the PID or title (as the value wouldn't be shown in the list of autocomplete results).
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No
- **Could this change impact execution of existing code?** Unlikely.

**Tagging:** @whikloj (as maintainer)

---

Adam Vessey
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
