### PR TITLE
Set the title for the child object to be rendered.

### DIFF
--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -252,6 +252,7 @@ function islandora_compound_object_islandora_compoundCModel_islandora_view_objec
     $first_child_id = reset($children);
     if ($first_child_id != $object->id) {
       $first_child = islandora_object_load($first_child_id);
+      drupal_set_title($first_child->label);
       return islandora_view_object($first_child);
     }
   }


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1596 
# What does this Pull Request do?

Sets the title for the first child object being rendered explicitly where it was previously handled in islandora_view_object.
# How should this be tested?

Create a compound object, add a child and view the compound object. Note how the label on the view object page is that of the child.
# Background context:

Previously, compound was relying on islandora_view_object to set the title for the object which was causing extra requests that were unneeded.
# Additional Notes:
- **Does this change require documentation to be updated?** No.
- **Does this change add any new dependencies?** No.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No.
- **Could this change impact execution of existing code?** No.
# Additional Information

Depends on https://github.com/Islandora/islandora/pull/644.

**Tagging:** @whikloj

---

Jordan Dukart
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
