### PR TITLE
Update Screen Shot

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Set the 'Child releationship predicate' and 'Solr filter query', as well as sele
 Optionally, enable the JAIL compound block to utilize the lazy loading image
 ability as outlined below.
 
-![Configuration](https://raw.githubusercontent.com/dmoses/islandora_screenshots/master/compound-admin.png)
+![Configuration](https://cloud.githubusercontent.com/assets/2738244/19966518/7943aba2-a1a2-11e6-8e17-9da13ef23fc6.png)
 
 **Block**:
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1844

# What does this Pull Request do?

Updates the screenshot

# What's new?

The "Display compound object parents in the breadcrumbs on children objects." checkbox is missing. This includes the missing field and highlights the area of interest.

# How should this be tested?
Look at the screen shot and see if it matches the default (vagrant) interface. 

# Additional Notes:
n/a

# Interested parties
@whikloj 

