### PR TITLE
Update to allow many objects in a compound object

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -11,6 +11,12 @@
  * Module admin form.
  */
 function islandora_compound_object_admin_form($form, &$form_state) {
+
+  $backend_options = module_invoke_all('islandora_compound_object_query_backends');
+  $map_to_title = function ($backend) {
+    return $backend['title'];
+  };
+
   $form = array();
 
   $form['islandora_compound_object_compound_children'] = array(
@@ -74,11 +80,21 @@ function islandora_compound_object_admin_form($form, &$form_state) {
     '#default_value' => variable_get('islandora_compound_object_use_jail_view', FALSE),
     '#element_validate' => array('islandora_compound_object_admin_form_jail_validation'),
   );
+
   $form['islandora_compound_object_show_compound_parents_in_breadcrumbs'] = array(
     '#type' => 'checkbox',
     '#title' => t('Display compound object parents in the breadcrumbs on children objects.'),
     '#default_value' => variable_get('islandora_compound_object_show_compound_parents_in_breadcrumbs', FALSE),
   );
+
+  $form['islandora_compound_object_query_backend'] = array(
+    '#type' => 'radios',
+    '#title' => t('Compound Member Query'),
+    '#description' => t('Select the method that will be used to find the children of the compound objects.'),
+    '#options' => array_map($map_to_title, $backend_options),
+    '#default_value' => variable_get('islandora_compound_object_query_backend', ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND),
+  );
+
   return system_settings_form($form);
 }
 

--- a/includes/backends.inc
+++ b/includes/backends.inc
@@ -1,0 +1,131 @@
+<?php
+
+/**
+ * @file
+ * Holds backend callable definitions for the compound solution pack.
+ */
+
+/**
+ * Implements callback_islandora_compound_object_query_backends().
+ */
+function islandora_compound_object_legacy_query_sparql($pid) {
+  $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
+  $objects = array();
+
+  $connection = islandora_get_tuque_connection();
+  $escaped_pid = str_replace(':', '_', $pid);
+  if ($connection) {
+    $query = <<<EOQ
+PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
+SELECT ?object ?title ?seq
+FROM <#ri>
+WHERE {
+  ?object <fedora-model:label> ?title ;
+          <fedora-rels-ext:$rels_predicate> <info:fedora/$pid> .
+  OPTIONAL {
+    ?object islandora-rels-ext:isSequenceNumberOf$escaped_pid ?seq
+  }
+}
+EOQ;
+    $results = $connection->repository->ri->sparqlQuery($query);
+
+    // Sort the objects into their proper order.
+    $sort = function($a, $b) {
+      $a = $a['seq']['value'];
+      $b = $b['seq']['value'];
+      if ($a === $b) {
+        return 0;
+      }
+      if (empty($a)) {
+        return 1;
+      }
+      if (empty($b)) {
+        return -1;
+      }
+      return $a - $b;
+    };
+    uasort($results, $sort);
+
+    foreach ($results as $result) {
+      $object = islandora_object_load($result['object']['value']);
+      if (islandora_object_access(ISLANDORA_VIEW_OBJECTS, $object)) {
+        $objects[$result['object']['value']] = array(
+          'pid' => $result['object']['value'],
+          'title' => $result['title']['value'],
+          'seq' => $result['seq']['value'],
+        );
+      }
+    }
+  }
+
+  return $objects;
+}
+
+/**
+ * Implements callback_islandora_compound_object_query_backends().
+ */
+function islandora_compound_object_query_sparql($pid) {
+  module_load_include('inc', 'islandora', 'includes/utilities');
+
+  $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
+  $objects = array();
+
+  // Handle XACML restrictions in query.
+  global $user;
+  if ($user->uid === 0) {
+    $user_name = 'anonymous';
+  }
+  else {
+    $user_name = $user->name;
+  }
+
+  $role_matches = array();
+  foreach ($user->roles as $role) {
+    $role_matches[] = "?role='{$role}'";
+  }
+  $role_matcher = implode(' || ', $role_matches);
+
+  // Handle namespace restrictions in query.
+  $enforced = variable_get('islandora_namespace_restriction_enforced', FALSE);
+  $namespace_filter = '';
+  if ($enforced) {
+    $namespace_array = islandora_get_allowed_namespaces();
+    $namespace_sparql = implode('|', $namespace_array);
+    $namespace_filter = format_string('FILTER(regex(str(?object), "info:fedora/(!namespaces):"))', array('!namespaces' => $namespace_sparql));
+  }
+
+  $escaped_pid = str_replace(':', '_', $pid);
+  $query = <<<EOQ
+PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
+SELECT DISTINCT ?object ?title ?seq
+FROM <#ri>
+WHERE {
+  ?object <fedora-model:label> ?title ;
+          <fedora-rels-ext:$rels_predicate> <info:fedora/$pid> .
+  OPTIONAL {
+      ?object islandora-rels-ext:isSequenceNumberOf$escaped_pid ?seq
+  }
+  OPTIONAL {{
+      ?object islandora-rels-ext:isViewableByRole ?role
+    } UNION {
+      ?object islandora-rels-ext:isViewableByUser ?user
+  }}
+  FILTER((!bound(?role) && !bound(?user)) || (bound(?user) && ?user='{$user_name}') || (bound(?role) && ($role_matcher)))
+  $namespace_filter
+}
+ORDER BY ASC(?seq)
+EOQ;
+
+  $connection = islandora_get_tuque_connection();
+  $results = $connection ? $connection->repository->ri->sparqlQuery($query) : array();
+
+  foreach ($results as $result) {
+    $objects[$result['object']['value']] = array(
+      'pid' => $result['object']['value'],
+      'title' => $result['title']['value'],
+      'seq' => $result['seq']['value'],
+    );
+  }
+
+  return $objects;
+}

--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -15,12 +15,8 @@ function islandora_compound_object_jail_display_block() {
   $block = array();
   $object = menu_get_object('islandora_object', 2);
   if ($object) {
-    // If only compound cmodel objects can be compound, this isn't necessary.
-    $children = islandora_compound_object_get_parts($object);
-    $pid = (!empty($children)) ? $children[0] : $object->id;
-    $compound_object = islandora_object_load($pid);
-    $compound_info = islandora_compound_object_retrieve_compound_info($compound_object);
-    if ($compound_info) {
+    $compound_info = islandora_compound_object_retrieve_compound_info($object);
+    if (!empty($compound_info)) {
       $module_path = drupal_get_path('module', 'islandora_compound_object');
       $jail_path = libraries_get_path('JAIL');
       $block['#attached']['js'] = array(
@@ -33,6 +29,14 @@ function islandora_compound_object_jail_display_block() {
         "$module_path/js/compound_jail.js" => array(
           'group' => JS_LIBRARY,
         ),
+      );
+      $block['#attached']['js'][] = array(
+        'data' => array(
+          'islandora_compound_object' => array(
+            'image_path' => url(drupal_get_path('module', 'islandora') . '/images/folder.png'),
+          ),
+        ),
+        'type' => 'setting',
       );
       $block['#attached']['css'] = array(
         "$module_path/css/islandora_compound_object.jail_block.css",
@@ -51,21 +55,13 @@ function islandora_compound_object_jail_display_block() {
           '#markup' => l(t('manage parent'), $compound_info['parent_url']),
         );
       }
-      foreach ($compound_info['siblings'] as $sibling) {
-        $sibling_object = islandora_object_load($sibling);
-        if (isset($sibling_object['TN']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $sibling_object['TN'])) {
-          $path = 'islandora/object/' . $sibling . '/datastream/TN/view';
-        }
-        else {
-          // Object either does not have a thumbnail or it's restricted show a
-          // default in its place.
-          $image_path = drupal_get_path('module', 'islandora');
-          $path = "$image_path/images/folder.png";
-        }
+
+      foreach ($compound_info['siblings_detailed'] as $sibling) {
+        $path = 'islandora/object/' . $sibling['pid'] . '/datastream/TN/view';
         $class = array(
           'islandora-compound-object-jail',
         );
-        if ($sibling == $pid) {
+        if ($sibling['pid'] == $compound_info['current_pid']) {
           $class[] = 'islandora-compound-object-jail-active';
         }
         $img = array(
@@ -76,7 +72,7 @@ function islandora_compound_object_jail_display_block() {
               'class' => $class,
               'data-src' => url($path),
             ),
-            '#href' => "islandora/object/$sibling",
+            '#href' => "islandora/object/{$sibling['pid']}",
           ),
           'noscript' => array(
             '#theme' => 'image',
@@ -85,18 +81,18 @@ function islandora_compound_object_jail_display_block() {
             '#suffix' => '</noscript>',
           ),
         );
-        $block[$sibling] = array(
+        $block[$sibling['pid']] = array(
           '#type' => 'container',
           '#attributes' => array(),
           'link' => array(
             '#type' => 'link',
-            '#title' => t("@title", array("@title" => $sibling_object->label)),
-            '#href' => "islandora/object/$sibling",
+            '#title' => t("@title", array("@title" => $sibling['title'])),
+            '#href' => "islandora/object/{$sibling['pid']}",
           ),
           'content' => array(
             '#theme' => 'link',
             '#text' => drupal_render($img),
-            '#path' => "islandora/object/$sibling",
+            '#path' => "islandora/object/{$sibling['pid']}",
             '#options' => array(
               'attributes' => array(),
               'html' => TRUE,
@@ -123,10 +119,6 @@ function islandora_compound_object_navigation_block(AbstractObject $object = NUL
   drupal_add_css(drupal_get_path('module', 'islandora_compound_object') . '/css/islandora_compound_object.block.css');
   $object = $object ? $object : menu_get_object('islandora_object', 2);
   if ($object) {
-    // If only compound cmodel objects can be compound, this isn't necessary.
-    $children = islandora_compound_object_get_parts($object->id);
-    $pid = (!empty($children)) ? $children[0] : $object->id;
-    $object = islandora_object_load($pid);
     $output = '';
     if ($object) {
       $compound_info = islandora_compound_object_retrieve_compound_info($object);

--- a/islandora_compound_object.api.php
+++ b/islandora_compound_object.api.php
@@ -39,3 +39,57 @@ function hook_islandora_compound_object_management_control_paths() {
     'islandora/object/%/your/menu/path/here',
   );
 }
+
+/**
+ * Describe query "backends" which might be selected between.
+ *
+ * We have a number of different mechanisms which might be used to generate
+ * lists of PIDs belonging to given compound objects, so let us roll an
+ * interface so we can talk to them in a consistent manner.
+ *
+ * @return array
+ *   Should return an associative array mapping unique (module-prefixed,
+ *   preferably) keys to associative arrays containing:
+ *   - title: A human-readable title for the backend.
+ *   - description: A description of the backend.
+ *   - callable: A PHP callable to call for this backend, implementing
+ *     callback_islandora_compound_object_query_backends().
+ *   - file: An optional file to load before attempting to call the callable.
+ */
+function hook_islandora_compound_object_query_backends() {
+  $a_callable = function ($pid, $ret_title) {
+    // Do something to get the total number of objects
+  };
+  return array(
+    'awesome_backend' => array(
+      'title' => t('Awesome Backend'),
+      'callable' => $a_callable,
+    ),
+  );
+}
+
+/**
+ * Return an array of pids that are part of a compound object.
+ *
+ * Callback for hook_islandora_compound_object_query_backends().
+ *
+ * @param String $pid
+ *   A compound object for which to obtain members.
+ *
+ * @return array
+ *   An array of arrays sorted in the order the compound objects should be
+ *   displayed with the PID of the compound object member as the array key for
+ *   each entry and the array for each compound member containing:
+ *   - pid: The PID of the object.
+ *   - title: The title of the object.
+ *   - seq: The sequence number of the object.
+ */
+function callback_islandora_compound_object_get_parts($pid) {
+  return array(
+    'islandora:123' => array(
+        'pid' => 'islandora:123',
+        'title' => 'objects title',
+        'seq' => 60,
+    ),
+  );
+}

--- a/islandora_compound_object.install
+++ b/islandora_compound_object.install
@@ -29,6 +29,7 @@ function islandora_compound_object_uninstall() {
     'islandora_compound_object_hide_child_objects_solr',
     'islandora_compound_object_solr_fq',
     'islandora_compound_object_use_jail_view',
+    'islandora_compound_object_query_backend',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -10,6 +10,8 @@
 
 define('ISLANDORA_COMPOUND_OBJECT_CMODEL', 'islandora:compoundCModel');
 
+const ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND = 'islandora_compound_object_legacy_sparql';
+
 /**
  * Implements hook_menu().
  */
@@ -412,74 +414,27 @@ function islandora_compound_object_islandora_solr_query($islandora_solr_query) {
  * Return an array of pids that are part of a compound object.
  */
 function islandora_compound_object_get_parts($pid, $ret_title = FALSE) {
-  $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
-  $objects = array();
 
-  global $user;
-  if ($user->uid === 0) {
-    $user_name = 'anonymous';
+  $backend = variable_get('islandora_compound_object_query_backend', ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND);
+  $backends = module_invoke_all('islandora_compound_object_query_backends');
+
+  if (!isset($backends[$backend])) {
+    $backend = ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND;
+  }
+
+  if (isset($backends[$backend]['file'])) {
+    require_once $backends[$backend]['file'];
+  }
+
+  $results = call_user_func($backends[$backend]['callable'], $pid);
+
+  if ($ret_title) {
+    $objects = $results;
   }
   else {
-    $user_name = $user->name;
-  }
-
-  $role_matches = array();
-  foreach ($user->roles as $role) {
-    $role_matches[] = "?role='{$role}'";
-  }
-  $role_matcher = implode(' || ', $role_matches);
-
-  $connection = islandora_get_tuque_connection();
-  $escaped_pid = str_replace(':', '_', $pid);
-  if ($connection) {
-    $query = <<<EOQ
-PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
-SELECT DISTINCT ?object ?title ?seq
-FROM <#ri>
-WHERE {
-  ?object <fedora-model:label> ?title ;
-          <fedora-rels-ext:$rels_predicate> <info:fedora/$pid> .
-  OPTIONAL {
-      ?object islandora-rels-ext:isSequenceNumberOf$escaped_pid ?seq
-  }
-  OPTIONAL {{
-      ?object <islandora-rels-ext:isViewableByRole> ?role
-    } UNION {
-      ?object <islandora-rels-ext:isViewableByUser> ?user
-  }}
-  FILTER((!bound(?role) && !bound(?user)) || (bound(?user) && ?user='{$user_name}') || (bound(?role) && ($role_matcher)))
-}
-EOQ;
-    $results = $connection->repository->ri->sparqlQuery($query);
-
-    // Sort the objects into their proper order.
-    $sort = function($a, $b) {
-      $a = $a['seq']['value'];
-      $b = $b['seq']['value'];
-      if ($a === $b) {
-        return 0;
-      }
-      if (empty($a)) {
-        return 1;
-      }
-      if (empty($b)) {
-        return -1;
-      }
-      return $a - $b;
-    };
-    uasort($results, $sort);
-
+    $objects = array();
     foreach ($results as $result) {
-      if ($ret_title) {
-        $objects[$result['object']['value']] = array(
-          'pid' => $result['object']['value'],
-          'title' => $result['title']['value'],
-          'seq' => $result['seq']['value'],
-        );
-      }
-      else {
-        $objects[] = $result['object']['value'];
-      }
+      $objects[] = $result['pid'];
     }
   }
 
@@ -699,4 +654,24 @@ function islandora_compound_object_islandora_get_breadcrumb_query_predicates(Abs
       format_string('fedora-rels-ext:!compound_rels', array('!compound_rels' => variable_get('islandora_compound_object_relationship', 'isConstituentOf'))),
     );
   }
+}
+
+/**
+ * Implements hook_islandora_compound_object_query_backends().
+ */
+function islandora_compound_object_islandora_compound_object_query_backends() {
+  $module_path = drupal_get_path('module', 'islandora_compound_object');
+
+  return array(
+    ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND => array(
+      'title' => t('(Default) Legacy SPARQL - Does a SPARQL query followed by an access check.'),
+      'callable' => 'islandora_compound_object_legacy_query_sparql',
+      'file' => "$module_path/includes/backends.inc",
+    ),
+    'islandora_basic_collection_sparql_query_backend' => array(
+      'title' => t('SPARQL - Does a SPARQL query with filters. Generally faster than the default option.'),
+      'callable' => 'islandora_compound_object_query_sparql',
+      'file' => "$module_path/includes/backends.inc",
+    ),
+  );
 }

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -415,19 +415,39 @@ function islandora_compound_object_get_parts($pid, $ret_title = FALSE) {
   $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
   $objects = array();
 
+  global $user;
+  if ($user->uid === 0) {
+    $user_name = 'anonymous';
+  }
+  else {
+    $user_name = $user->name;
+  }
+
+  $role_matches = array();
+  foreach ($user->roles as $role) {
+    $role_matches[] = "?role='{$role}'";
+  }
+  $role_matcher = implode(' || ', $role_matches);
+
   $connection = islandora_get_tuque_connection();
   $escaped_pid = str_replace(':', '_', $pid);
   if ($connection) {
     $query = <<<EOQ
 PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
-SELECT ?object ?title ?seq
+SELECT DISTINCT ?object ?title ?seq
 FROM <#ri>
 WHERE {
   ?object <fedora-model:label> ?title ;
           <fedora-rels-ext:$rels_predicate> <info:fedora/$pid> .
   OPTIONAL {
-    ?object islandora-rels-ext:isSequenceNumberOf$escaped_pid ?seq
+      ?object islandora-rels-ext:isSequenceNumberOf$escaped_pid ?seq
   }
+  OPTIONAL {{
+      ?object <islandora-rels-ext:isViewableByRole> ?role
+    } UNION {
+      ?object <islandora-rels-ext:isViewableByUser> ?user
+  }}
+  FILTER((!bound(?role) && !bound(?user)) || (bound(?user) && ?user='{$user_name}') || (bound(?role) && ($role_matcher)))
 }
 EOQ;
     $results = $connection->repository->ri->sparqlQuery($query);
@@ -450,18 +470,15 @@ EOQ;
     uasort($results, $sort);
 
     foreach ($results as $result) {
-      $object = islandora_object_load($result['object']['value']);
-      if (islandora_object_access(ISLANDORA_VIEW_OBJECTS, $object)) {
-        if ($ret_title) {
-          $objects[$result['object']['value']] = array(
-            'pid' => $result['object']['value'],
-            'title' => $result['title']['value'],
-            'seq' => $result['seq']['value'],
-          );
-        }
-        else {
-          $objects[] = $result['object']['value'];
-        }
+      if ($ret_title) {
+        $objects[$result['object']['value']] = array(
+          'pid' => $result['object']['value'],
+          'title' => $result['title']['value'],
+          'seq' => $result['seq']['value'],
+        );
+      }
+      else {
+        $objects[] = $result['object']['value'];
       }
     }
   }
@@ -520,10 +537,7 @@ function islandora_compound_object_menu_local_tasks_alter(&$data, $router_item, 
   if (variable_get('islandora_compound_object_use_jail_view', FALSE)) {
     $valid_paths = module_invoke_all('islandora_compound_object_management_control_paths');
     if (strpos($root_path, 'islandora/object/%') === 0) {
-      $object = menu_get_object('islandora_object', 2);
-      $children = islandora_compound_object_get_parts($object->id);
-      $pid = (!empty($children)) ? $children[0] : $object->id;
-      $compound_object = islandora_object_load($pid);
+      $compound_object = menu_get_object('islandora_object', 2);
       $compound_info = islandora_compound_object_retrieve_compound_info($compound_object);
       if ($compound_info) {
         drupal_set_title(t('@parent - @child', array(
@@ -591,7 +605,8 @@ function islandora_compound_object_menu_local_tasks_alter(&$data, $router_item, 
  * Helper function to retrieve relevant information about the compound.
  *
  * @param AbstractObject $object
- *   An AbstractObject representing an object within Fedora.
+ *   An AbstractObject representing an object within Fedora. This object can
+ *   either be the child of a compound, or the compound object itself.
  *
  * @return array
  *   An array describing the compound containining:
@@ -603,8 +618,11 @@ function islandora_compound_object_menu_local_tasks_alter(&$data, $router_item, 
  *   an empty string if one does not exist.
  *   -next_pid: A string with the pid of the next pid in the sequence, an empty
  *   string if one does not exist.
+ *   -current_pid: Either the PID of the object passed in, or the first child
+ *   if the object passed in is the parent.
  *   -child_count: An integer of the number of children the object has.
  *   -siblings: An array containing the siblings of the compound.
+ *   -siblings_detailed: An array containing the details of sibling objects.
  *   -pid: A string that is the pid of the current object we are on.
  *   -label: A string containing the label of the object.
  *   -sequence: An integer that is the sequence number of the current object.
@@ -613,40 +631,51 @@ function islandora_compound_object_retrieve_compound_info(AbstractObject $object
   $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
   $part_of = $object->relationships->get(FEDORA_RELS_EXT_URI, $rels_predicate);
   $info = array();
-  // This object is part of a compound object.
-  if (!empty($part_of)) {
-    // Go through all parents.
-    foreach ($part_of as $part) {
-      $parent_pid = $part['object']['value'];
-      $parent = islandora_object_load($parent_pid);
-      if ($parent) {
-        $siblings = islandora_compound_object_get_parts($parent_pid);
-        $current_key = array_search($object->id, $siblings);
-        $previous_pid = (isset($siblings[$current_key - 1])) ? $siblings[$current_key - 1] : '';
-        $next_pid = (isset($siblings[$current_key + 1])) ? $siblings[$current_key + 1] : '';
 
-        // Check if perms to show link for parent manage.
-        if (islandora_object_manage_access_callback(array(
-          ISLANDORA_METADATA_EDIT, ISLANDORA_MANAGE_PROPERTIES, ISLANDORA_ADD_DS), $parent)) {
-          $parent_url = 'islandora/object/' . $parent_pid . '/manage';
-        }
-        else {
-          $parent_url = FALSE;
-        }
-        $info = array(
-          'parent_label' => $parent->label,
-          'parent_pid' => $parent_pid,
-          'parent_url' => $parent_url,
-          'previous_pid' => $previous_pid,
-          'next_pid' => $next_pid,
-          'child_count' => count($siblings),
-          'siblings' => $siblings,
-          'pid' => $object->id,
-          'label' => $object->label,
-          'sequence' => $current_key + 1,
-        );
-      }
+  // This object is the child of a compound object.
+  if (!empty($part_of)) {
+    // XXX: Handle the case where we are a member of multiple compounds?
+    // For now just grab the last value in the array.
+    $part = array_pop($part_of);
+    $parent_pid = $part['object']['value'];
+    $parent = islandora_object_load($parent_pid);
+  }
+  // Assume this object is the parent compound object.
+  else {
+    $parent_pid = $object->id;
+    $parent = $object;
+  }
+
+  $siblings_detailed = islandora_compound_object_get_parts($parent_pid, TRUE);
+  if (!empty($siblings_detailed)) {
+    $siblings = array_keys($siblings_detailed);
+    $current_key = ($parent === $object) ? 0 : array_search($object->id, $siblings);
+    $previous_pid = (isset($siblings[$current_key - 1])) ? $siblings[$current_key - 1] : '';
+    $next_pid = (isset($siblings[$current_key + 1])) ? $siblings[$current_key + 1] : '';
+
+    // Check if perms to show link for parent manage.
+    if (islandora_object_manage_access_callback(array(
+      ISLANDORA_METADATA_EDIT, ISLANDORA_MANAGE_PROPERTIES, ISLANDORA_ADD_DS), $parent)) {
+      $parent_url = 'islandora/object/' . $parent_pid . '/manage';
     }
+    else {
+      $parent_url = FALSE;
+    }
+
+    $info = array(
+      'parent_label' => $parent->label,
+      'parent_pid' => $parent_pid,
+      'parent_url' => $parent_url,
+      'previous_pid' => $previous_pid,
+      'next_pid' => $next_pid,
+      'current_pid' => $siblings[$current_key],
+      'child_count' => count($siblings),
+      'siblings' => $siblings,
+      'siblings_detailed' => $siblings_detailed,
+      'pid' => $object->id,
+      'label' => $object->label,
+      'sequence' => $current_key + 1,
+    );
   }
   return $info;
 }

--- a/js/compound_jail.js
+++ b/js/compound_jail.js
@@ -8,7 +8,15 @@
         attach: function(context, settings) {
             $('img.islandora-compound-object-jail').jail({
                 triggerElement:'#block-islandora-compound-object-compound-jail-display',
-                event: 'scroll'
+                event: 'scroll',
+                error: function($img, options) {
+                    if( $img.attr("src") == Drupal.settings.islandora_compound_object.image_path ) {
+                        return;
+                    }
+
+                    $img.attr("data-src", Drupal.settings.islandora_compound_object.image_path);
+                    $img.trigger('scroll');
+                }
             });
         }
     };


### PR DESCRIPTION
**JIRA Ticket**:

https://jira.duraspace.org/browse/ISLANDORA-1846

# What does this Pull Request do?

Currently when a compound object is loaded we call `islandora_object_load` on each member of the compound object twice during the process of rendering the page. This causes page loads to be very slow when a compound object has many children. This pull request eliminates these calls when using the "JAIL" block so that compounds will load fairly quickly.

# What's new?

* Modify the `islandora_compound_object_retrieve_compound_info` function 
  * So it can accept either  the child of a compound object or the parent. Before it would only accept the child, so we had to do checks before we called it to make sure we were the child not the parent. This allows us to eliminate one RI query when loading the object.
  * To return two extra values in its return array:
    * `current_pid`
    * `siblings_detailed`
* Modify the SPARQL query used to find the children of the compound object to add filters for XACML so if an object has XACML on it, it will be filtered out on a per-user basis. This query will work just like the one used before if the repository is not using XACML. This lets us eliminate one use of `islandora_object_load`.
* Modify the javascript code we use to lazy load the images using the JAIL library, so that if an image isn't found at load time we fall back to a default image. This lets us eliminate the other use of `islandora_object_load`.  

# How should this be tested?

* Load a large number of children to a compound object (I've been using 500 in my testing). 
  * Test that before the pull request the page takes a long time to load (minutes). 
  * Test that after applying the pull request the page loads in a normal amount of time.
  * Apply an XACML object to block viewing of an object
    * Make sure that it appears when a user has access. 
    * Make sure it doesn't apply when a user doesn't have access.
  * Apply an XACML policy that blocks an object TN datastream. 
    * Make sure that the JAIL display correctly falls back to the usual islandora "folder" image. 

# Interested parties
@whikloj @jordandukart 