### PR TITLE
ISLANDORA-1911 - readme updates

### DIFF
--- a/modules/islandora_compound_object_zip_importer/README.md
+++ b/modules/islandora_compound_object_zip_importer/README.md
@@ -32,7 +32,8 @@ Current maintainers:
 
 ## Development
 
-If you would like to contribute to this module, please check out our helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the Islandora.ca site.
+If you would like to contribute to this module, please check out [CONTRIBUTING.md](CONTRIBUTING.md). In addition, we have helpful [Documentation for Developers](https://github.com/Islandora/islandora/wiki#wiki-documentation-for-developers) info, as well as our [Developers](http://islandora.ca/developers) section on the [Islandora.ca](http://islandora.ca) site.
+
 
 ## License
 

--- a/modules/islandora_compound_object_zip_importer/README.md
+++ b/modules/islandora_compound_object_zip_importer/README.md
@@ -11,7 +11,7 @@ This module requires the following modules/libraries:
 * [Islandora](https://github.com/islandora/islandora)
 * [Tuque](https://github.com/islandora/tuque)
 * [Islandora Basic Collection](https://github.com/Islandora/islandora_solution_pack_collection)
-* [Islandora ZIP Importer](https://github.com/discoverygarden/islandora_importer/tree/7.x/modules/zip_importer)
+* [Islandora ZIP Importer](https://github.com/islandora/islandora_importer/tree/7.x/modules/zip_importer)
 
 ## Installation
 
@@ -28,7 +28,7 @@ Having problems or solved a problem? Check out the Islandora google groups for a
 
 Current maintainers:
 
-* [Jordan Dukart](https://github.com/jordandukart)
+* [Jared Whiklo](https://github.com/whikloj)
 
 ## Development
 


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1911

* Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)

# What does this Pull Request do?

Updates a link to point to the Islandora Github. Updates Maintainer to match parent module. Updates Development section to match current readme template.

# How should this be tested?

Just readme stuff, so have a look at the changes, verify the link, see that Maintainer matches the record in the [release team spreadsheet](https://docs.google.com/spreadsheets/d/1PRv2Xo-sNE_sDJHUT5OvTXmNiSHnkdJgwo7VsFkIUgY) for the latest version. 

# Interested parties
@DiegoPino since he's looking at the others on this JIRA ticket already 😄 
