### PR TITLE
Resolves ISLANDORA-1922

### DIFF
--- a/modules/islandora_compound_object_zip_importer/islandora_compound_object_zip_importer.module
+++ b/modules/islandora_compound_object_zip_importer/islandora_compound_object_zip_importer.module
@@ -78,4 +78,25 @@ function islandora_compound_object_zip_importer_import_form_validate($form, $for
  */
 function islandora_compound_object_zip_importer_import_form_submit($form, $form_state) {
   islandora_importer_form_submit($form, $form_state);
+
+  if (variable_get('islandora_compound_object_thumbnail_child', TRUE)) {
+    $batch = array();
+    $batch['operations'][] = array('islandora_compound_object_zip_importer_set_thumbnail', array($form_state['storage']['parent_pid']));
+    $batch['title'] = t('Setting parent thumbnail');
+    batch_set($batch);
+  }
 }
+
+/**
+ * A batch callback function to set the parent thumbnail if requested.
+ *
+ * @param string $pid
+ *   The PID of the parent.
+ * @param array $context
+ *   The batch context.
+ */
+function islandora_compound_object_zip_importer_set_thumbnail($pid, &$context) {
+  islandora_compound_object_update_parent_thumbnail(islandora_object_load($pid));
+  $context['finished'] = 1;
+}
+


### PR DESCRIPTION
**JIRA Ticket**: (link)
https://jira.duraspace.org/browse/ISLANDORA-1922

# What does this Pull Request do?

Makes sure the thumbnail gets set on the parent object if requested by settings.

# What's new?

Adds a new batch set to the batch done by the islandora_compound_object_zip_importer to make sure the thumbnail is set correctly on the parent object after the batch ingest is complete.

# How should this be tested?

Without pull request:
* Create a new empty compound object. 
* Use batch ingest to add objects to compound.
* See that no thumbnail is set on parent.

With pull request:
* Create a new empty compound object.
* Use batch ingest to add objects to compound. 
* See that the parent now has a thumbnail.

# Interested parties
@whikloj @DiegoPino 