### PR TITLE
Change hook name to proper model name.

### DIFF
--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -270,7 +270,7 @@ function islandora_compound_object_access(AbstractObject $object) {
 /**
  * Implements hook_compound_cmodel_islandora_derivative().
  */
-function islandora_compound_object_compoundCModel_islandora_derivative(AbstractObject $object = NULL, $ds_modified_params = array()) {
+function islandora_compound_object_islandora_compoundCModel_islandora_derivative(AbstractObject $object = NULL, $ds_modified_params = array()) {
   $module_path = drupal_get_path('module', 'islandora_compound_object');
   $derivatives = array();
   if (variable_get('islandora_compound_object_tn_deriv_hooks', FALSE)) {

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -268,7 +268,7 @@ function islandora_compound_object_access(AbstractObject $object) {
 }
 
 /**
- * Implements hook_compound_cmodel_islandora_derivative().
+ * Implements hook_CMODEL_islandora_derivative().
  */
 function islandora_compound_object_islandora_compoundCModel_islandora_derivative(AbstractObject $object = NULL, $ds_modified_params = array()) {
   $module_path = drupal_get_path('module', 'islandora_compound_object');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2052


# What does this Pull Request do?
Currently the islandora_compound_object_compoundCModel_islandora_derivative hook  https://github.com/Islandora/islandora_solution_pack_compound/blob/7.x/islandora_compound_object.module#L273 is named wrong, the Cmodel should be islandora_compoundCModel NOT compoundCModel. This renaming allows the hook to fire properly.

# What's new?
Renamed islandora_compound_object_compoundCModel_islandora_derivative hook to islandora_compound_object_islandora_compoundCModel_islandora_derivative.

Example:
N/A

# How should this be tested?
This appears to be an edge case since there is redundancy built in for most use-cases. i.e. https://github.com/Islandora/islandora_solution_pack_compound/blob/7.x/islandora_compound_object.module#L292 was masking this bug.   
To reproduce the problem, ingest a compound object with some debugging around islandora_compound_object_compoundCModel_islandora_derivative. The derivative should not fire. 
Once the fix is employed, the derivative should fire.

# Additional Notes:
N/A

# Interested parties
@Islandora/7-x-1-x-committers
