### PR TITLE
ISLANDORA-2058 Redirect to first item of a compound when going to a compound

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -94,6 +94,13 @@ function islandora_compound_object_admin_form($form, &$form_state) {
     '#default_value' => variable_get('islandora_compound_object_show_compound_parents_in_breadcrumbs', FALSE),
   );
 
+  $form['islandora_compound_object_redirect_to_first'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Redirect to first child when a compound object is requested.'),
+    '#description' => t('Compound objects themselves redirect to there first child when this setting is enabled. This solves the problem that blocks on compound views get the wrong context.'),
+    '#default_value' => variable_get('islandora_compound_object_redirect_to_first', FALSE),
+  );
+
   $form['islandora_compound_object_query_backend'] = array(
     '#type' => 'radios',
     '#title' => t('Compound Member Query'),

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -99,6 +99,7 @@ function islandora_compound_object_admin_form($form, &$form_state) {
     '#title' => t('Redirect to first child when a compound object is requested.'),
     '#description' => t('Compound objects themselves redirect to there first child when this setting is enabled. This solves the problem that blocks on compound views get the wrong context.'),
     '#default_value' => variable_get('islandora_compound_object_redirect_to_first', FALSE),
+    '#element_validate' => array('islandora_compound_object_admin_form_redirect_to_first_validation'),
   );
 
   $form['islandora_compound_object_query_backend'] = array(
@@ -129,6 +130,28 @@ function islandora_compound_object_admin_form_jail_validation(array $element, ar
     drupal_set_message(t('The <a href="@url">JAIL</a> library must be present in the libraries folder to use this display.', array(
       '@url' => url('https://github.com/sebarmeli/JAIL', array('absolute' => TRUE)),
     )), 'error');
+  }
+}
+
+/**
+ * Warn if both redirect to first and compound parent in breadcrumb are enabled.
+ *
+ * @param array $element
+ *   The element to check.
+ * @param array $form_state
+ *   The Drupal form state.
+ * @param array $form
+ *   The Drupal form definition.
+ */
+function islandora_compound_object_admin_form_redirect_to_first_validation(array $element, array &$form_state, array $form) {
+  if ($element['#value'] == 1) {
+    if (isset($form_state['values']['islandora_compound_object_show_compound_parents_in_breadcrumbs'])
+        && $form_state['values']['islandora_compound_object_show_compound_parents_in_breadcrumbs'] == 1) {
+      $first_title = rtrim($element['#title'], '.!?');
+      $parent_title = rtrim($form['islandora_compound_object_show_compound_parents_in_breadcrumbs']['#title'], '.!?');
+      drupal_set_message(t("Enabling both %first and %parent is not recommended, because the compound object parent in the breadcrumb will be redirect to the first child, so cannot be actually reached.",
+        array('%first' => $first_title, '%parent' => $parent_title)), 'warning');
+    }
   }
 }
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -97,7 +97,7 @@ function islandora_compound_object_admin_form($form, &$form_state) {
   $form['islandora_compound_object_redirect_to_first'] = array(
     '#type' => 'checkbox',
     '#title' => t('Redirect to first child when a compound object is requested.'),
-    '#description' => t('Compound objects themselves redirect to there first child when this setting is enabled. This solves the problem that blocks on compound views get the wrong context.'),
+    '#description' => t('Users will be redirected to the first child of a Compound Object when enabling this setting.'),
     '#default_value' => variable_get('islandora_compound_object_redirect_to_first', FALSE),
     '#element_validate' => array('islandora_compound_object_admin_form_redirect_to_first_validation'),
   );

--- a/islandora_compound_object.install
+++ b/islandora_compound_object.install
@@ -31,6 +31,7 @@ function islandora_compound_object_uninstall() {
     'islandora_compound_object_use_jail_view',
     'islandora_compound_object_query_backend',
     'islandora_compound_object_tn_deriv_hooks',
+    'islandora_compound_object_redirect_to_first',
   );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -248,40 +248,23 @@ function islandora_compound_object_xml_form_builder_form_associations() {
  * Implements hook_islandora_cmodel_islandora_view_object().
  */
 function islandora_compound_object_islandora_compoundCModel_islandora_view_object($object) {
-  // Get view of first child.
   $children = islandora_compound_object_get_parts($object->id);
   if (!empty($children)) {
     $first_child_id = reset($children);
     if ($first_child_id != $object->id) {
-      $first_child = islandora_object_load($first_child_id);
-      drupal_set_title($first_child->label);
-      return islandora_view_object($first_child);
-    }
-  }
-}
+      if (variable_get('islandora_compound_object_redirect_to_first', FALSE)) {
+        // Redirect to the first child of a compound.
+        $redirect_path = 'islandora/object/' . $first_child_id;
+        $options = array();
+        $options['query'] = drupal_get_query_parameters();
 
-/**
- * Implements hook_page_build().
- */
-function islandora_compound_object_page_build(&$page) {
-  // Redirect to first child of a compound if this is the compound page itself.
-  if (variable_get('islandora_compound_object_redirect_to_first', FALSE)) {
-    $item = menu_get_item();
-    if ($item && $item['path'] === 'islandora/object/%') {
-      $object = menu_get_object('islandora_object', 2);
-      if ($object) {
-        $children = islandora_compound_object_get_parts($object->id);
-        if (!empty($children)) {
-          // We found a compound with children, redirect to the first child.
-          $firstchild = $children[0];
-          if ($firstchild !== $object->id) {
-            $redirect_path = 'islandora/object/' . $firstchild;
-            $options = array();
-            $options['query'] = drupal_get_query_parameters();
-
-            drupal_goto($redirect_path, $options);
-          }
-        }
+        drupal_goto($redirect_path, $options);
+      }
+      else {
+        // Get view of first child.
+        $first_child = islandora_object_load($first_child_id);
+        drupal_set_title($first_child->label);
+        return islandora_view_object($first_child);
       }
     }
   }

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -261,30 +261,29 @@ function islandora_compound_object_islandora_compoundCModel_islandora_view_objec
 }
 
 /**
- * Implements hook_page_build(&$page).
+ * Implements hook_page_build().
  */
 function islandora_compound_object_page_build(&$page) {
   // Redirect to first child of a compound if this is the compound page itself.
   if (variable_get('islandora_compound_object_redirect_to_first', FALSE)) {
-    $curpath = current_path();
-    $pathparts = explode('/', $curpath); 
-    if (count($pathparts) === 3 && $pathparts[0] === 'islandora' && $pathparts[1] === 'object') {
+    $item = menu_get_item();
+    if ($item && $item['path'] === 'islandora/object/%') {
       $object = menu_get_object('islandora_object', 2);
       if ($object) {
         $children = islandora_compound_object_get_parts($object->id);
         if (!empty($children)) {
-          // we found a compound with children, redirect to the first child.
+          // We found a compound with children, redirect to the first child.
           $firstchild = $children[0];
           if ($firstchild !== $object->id) {
             $redirect_path = 'islandora/object/' . $firstchild;
             $options = array();
             $options['query'] = drupal_get_query_parameters();
 
-            drupal_goto($redirect_path, $options, 301);
+            drupal_goto($redirect_path, $options);
           }
         }
       }
-    } 
+    }
   }
 }
 

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -261,6 +261,34 @@ function islandora_compound_object_islandora_compoundCModel_islandora_view_objec
 }
 
 /**
+ * Implements hook_page_build(&$page).
+ */
+function islandora_compound_object_page_build(&$page) {
+  // Redirect to first child of a compound if this is the compound page itself.
+  if (variable_get('islandora_compound_object_redirect_to_first', FALSE)) {
+    $curpath = current_path();
+    $pathparts = explode('/', $curpath); 
+    if (count($pathparts) === 3 && $pathparts[0] === 'islandora' && $pathparts[1] === 'object') {
+      $object = menu_get_object('islandora_object', 2);
+      if ($object) {
+        $children = islandora_compound_object_get_parts($object->id);
+        if (!empty($children)) {
+          // we found a compound with children, redirect to the first child.
+          $firstchild = $children[0];
+          if ($firstchild !== $object->id) {
+            $redirect_path = 'islandora/object/' . $firstchild;
+            $options = array();
+            $options['query'] = drupal_get_query_parameters();
+
+            drupal_goto($redirect_path, $options, 301);
+          }
+        }
+      }
+    } 
+  }
+}
+
+/**
  * Access callback for compound object management.
  */
 function islandora_compound_object_access(AbstractObject $object) {


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2058

https://groups.google.com/forum/m/#!topic/islandora/ue4SMkvhdp4

# What does this Pull Request do?

Adds a configuration option that (if enabled) always redirects to the first item of the compound when a compound is viewed. The manage tab of the compound is still reachable.

# What's new?
When a compound is opened, it looks like the first item of that compound is selected. But the context on the page is that of the compound, causing other blocks on the page to display the information about the compound instead of the first item. For our users this is confusing and hard to explain. We can tell them to always click the first item, but we rather redirect to the first item automatically.
In this PR the hook_page_build is implemented to redirect to the first child if the current object has children. Also, in the admin form an option is added the enabled or disable this behaviour. If it is enabled and also the "display breadcrumbs" option is enabled, a warning is displayed because these two don't work together well.

# How should this be tested?

* click on a link to a compound
  * the actual compound is visible and you can see that the first item is displayed but not actually selected
* enable the redirect to first option in the admin form of the compound sp
* click on a link to a compound
  * now the first item of the compound is displayed and selected
* test with the JAIL option enabled
* test with Compound Member Query set to "Legacy SPARQL" and "SPARQL"
* test with other objects as compounds; "Only allow compound objects to have child objects" is disabled
* test with child with 2 parents; this gives unexpected behaviour, but is the same as when a user clicks on the first child of a compound and then finds that another compound is displayed. See JIRA ISLANDORA-1301.

# Additional Notes:
Is related to JIRA ISLANDORA-1301 but does not solve it.
The documentation should be updated, is not done because of screenshot.
This does not add any dependencies and can be enabled/disabled at any time.

# Interested parties
@Islandora/7-x-1-x-committers @whikloj @DiegoPino
