### PR TITLE
Lexicographic sorting and integer

### DIFF
--- a/includes/backends.inc
+++ b/includes/backends.inc
@@ -113,7 +113,7 @@ WHERE {
   FILTER((!bound(?role) && !bound(?user)) || (bound(?user) && ?user='{$user_name}') || (bound(?role) && ($role_matcher)))
   $namespace_filter
 }
-ORDER BY ASC(?seq)
+ORDER BY ASC(?seq+0)
 EOQ;
 
   $connection = islandora_get_tuque_connection();

--- a/includes/backends.inc
+++ b/includes/backends.inc
@@ -113,7 +113,7 @@ WHERE {
   FILTER((!bound(?role) && !bound(?user)) || (bound(?user) && ?user='{$user_name}') || (bound(?role) && ($role_matcher)))
   $namespace_filter
 }
-ORDER BY ASC(?seq+0)
+ORDER BY ASC(?seq + 0)
 EOQ;
 
   $connection = islandora_get_tuque_connection();


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2059

# What does this Pull Request do?
Cast the results of a sequence query to an integer to avoid the natural sort condition. 

# What's new?
N/A

# How should this be tested?
Test compound object sorting and verify the 2nd item is actually the 2nd and not the 10th.  

**This should change the behavior for results being returned from** 
_1,10,11,2,3,4,5,6,7,8,9_

**To**
_1,2,3,4,5,6,7,8,9,10,11_

# Additional Notes:
NOT COMPLETED TESTED!!! 
I was not completely able to test this. I thought throwing up a simple solution would be a simple and effective start. Lexicographic sorting is usually indicative to behavior. You could do an explicit cast by doing:

**ORDER BY CAST(?seq AS INTEGER)**

Reconsider the problem could possibly be addressed at the database layout; ?seq field contains only numeric values and therefore should also be of an numeric type.

# Interested parties
@Islandora/7-x-1-x-committers @nhart 
