### PR TITLE
ISLANDORA-2070 Fix losing query params

### DIFF
--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -56,6 +56,7 @@ function islandora_compound_object_jail_display_block() {
         );
       }
 
+      $query_params = drupal_get_query_parameters();
       foreach ($compound_info['siblings_detailed'] as $sibling) {
         $path = 'islandora/object/' . $sibling['pid'] . '/datastream/TN/view';
         $class = array(
@@ -88,6 +89,7 @@ function islandora_compound_object_jail_display_block() {
             '#type' => 'link',
             '#title' => t("@title", array("@title" => $sibling['title'])),
             '#href' => "islandora/object/{$sibling['pid']}",
+            '#options' => array('query' => $query_params),
           ),
           'content' => array(
             '#theme' => 'link',
@@ -96,6 +98,7 @@ function islandora_compound_object_jail_display_block() {
             '#options' => array(
               'attributes' => array(),
               'html' => TRUE,
+              'query' => $query_params,
             ),
           ),
         );

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -564,6 +564,7 @@ function islandora_compound_object_menu_local_tasks_alter(&$data, $router_item, 
         )), PASS_THROUGH);
       }
       if (isset($data['tabs'][0]['output'])) {
+        $query_params = drupal_get_query_parameters();
         foreach ($data['tabs'][0]['output'] as $key => &$tab) {
           if ($tab['#link']['path'] == 'islandora/object/%/compound_count') {
             if (in_array($root_path, $valid_paths) && !empty($compound_info)) {
@@ -591,6 +592,7 @@ function islandora_compound_object_menu_local_tasks_alter(&$data, $router_item, 
                   'id' => 'islandora-compound-previous-link',
                 ),
                 'html' => FALSE,
+                'query' => $query_params,
               );
             }
             else {
@@ -607,6 +609,7 @@ function islandora_compound_object_menu_local_tasks_alter(&$data, $router_item, 
                   'id' => 'islandora-compound-next-link',
                 ),
                 'html' => FALSE,
+                'query' => $query_params,
               );
             }
             else {

--- a/theme/islandora-compound-prev-next.tpl.php
+++ b/theme/islandora-compound-prev-next.tpl.php
@@ -52,6 +52,7 @@
  <?php endif; ?>
 
  <?php if (count($themed_siblings) > 0): ?>
+   <?php $query_params = drupal_get_query_parameters(); ?>
    <div class="islandora-compound-thumbs">
    <?php foreach ($themed_siblings as $sibling): ?>
      <div class="islandora-compound-thumb">
@@ -64,7 +65,7 @@
          )
        ),
        'islandora/object/' . $sibling['pid'],
-       array('html' => TRUE)
+       array('html' => TRUE, 'query' => $query_params)
      );?>
      </div>
    <?php endforeach; // each themed_siblings ?>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2070

# What does this Pull Request do?

When the user selects another child, the query parameters of the
original URL are lost. This prevends the solr search navigation from
working correctly. This fix adds the query parameters to the links of
the children.

# What's new?

This PR adds the query parameters to the links to the compound children in the template file and for the JAIL block.

# How should this be tested?

* Enable search navigation block (admin/islandora/search/islandora_solr/settings)
* Add "islandora search navigation" block to the page (admin/structure/block) and configure it if necessary
* Do a search that has compound objects in it's results
* Click a result
* Navigate to the next and previous results with the navigation links
* When on a compound object, click another child of this compound object
* The navigation links should be visible and working
* Repeat above steps for the JAIL block

# Additional Notes:

If the islandora-compound-prev-next.tpl.php is overwritten in your theme, make sure you do the exact same change there too.

# Interested parties

@Islandora/7-x-1-x-committers @whikloj @DiegoPino