### PR TITLE
ISLANDORA-2072 removed the ORDER BY from RI query and added sort nume…

### DIFF
--- a/includes/backends.inc
+++ b/includes/backends.inc
@@ -31,8 +31,8 @@ EOQ;
 
     // Sort the objects into their proper order.
     $sort = function($a, $b) {
-      $a = $a['seq']['value'];
-      $b = $b['seq']['value'];
+      $a = intval($a['seq']['value']);
+      $b = intval($b['seq']['value']);
       if ($a === $b) {
         return 0;
       }
@@ -113,11 +113,31 @@ WHERE {
   FILTER((!bound(?role) && !bound(?user)) || (bound(?user) && ?user='{$user_name}') || (bound(?role) && ($role_matcher)))
   $namespace_filter
 }
-ORDER BY ASC(?seq)
 EOQ;
+
+  // Removed the ORDER BY from the SPARQL query so that the values are sorted sequentially 
+  // by their integer NUMERIC values.
+  // ORDER BY ASC(?seq)
 
   $connection = islandora_get_tuque_connection();
   $results = $connection ? $connection->repository->ri->sparqlQuery($query) : array();
+
+  // Sort the objects into their proper order by their integer values.
+  $sort = function($a, $b) {
+    $a = intval($a['seq']['value']);
+    $b = intval($b['seq']['value']);
+    if ($a === $b) {
+      return 0;
+    }
+    if (empty($a)) {
+      return 1;
+    }
+    if (empty($b)) {
+      return -1;
+    }
+    return $a - $b;
+  };
+  uasort($results, $sort);
 
   foreach ($results as $result) {
     $objects[$result['object']['value']] = array(

--- a/includes/backends.inc
+++ b/includes/backends.inc
@@ -115,8 +115,8 @@ WHERE {
 }
 EOQ;
 
-  // Removed the ORDER BY from the SPARQL query so that the values are sorted sequentially 
-  // by their integer NUMERIC values.
+  // Removed the ORDER BY from the SPARQL query so that the values are sorted
+  // sequentially by their integer NUMERIC values.
   // ORDER BY ASC(?seq)
 
   $connection = islandora_get_tuque_connection();


### PR DESCRIPTION
…rically routine

**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2059

# What does this Pull Request do?

Ensure values are sorted numerically in both Sparql queries.

# How should this be tested?

You can't seem to use Mulgara for this, so you'll need a different triplestore. 

According to the ticket.

With the non-legacy SPARQL option enabled for "Compound Member Query", when the sequence gets over 1 digit the string sort doesn't work.
eg:
1
10
11
12
2
3

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies?  no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?  no
* Could this change impact execution of existing code? no

# Interested parties
@nhart 
