### PR TITLE
Fix double escaping

### DIFF
--- a/includes/blocks.inc
+++ b/includes/blocks.inc
@@ -87,7 +87,7 @@ function islandora_compound_object_jail_display_block() {
           '#attributes' => array(),
           'link' => array(
             '#type' => 'link',
-            '#title' => t("@title", array("@title" => $sibling['title'])),
+            '#title' => $sibling['title'],
             '#href' => "islandora/object/{$sibling['pid']}",
             '#options' => array('query' => $query_params),
           ),


### PR DESCRIPTION
## JIRA Ticket: 
https://dev-islandora.lyrasistechnology.org/islandora/object/lyrasis:3675

## What does this Pull Request do?

This was double escaping the title of compound objects with a needless `t()` function, remove the `t()` function and use the variable directly. 

![screen shot 2018-02-09 at 4 40 40 pm](https://user-images.githubusercontent.com/569437/36049174-3e9eafaa-0db8-11e8-969e-c0165d94b508.png)

## What's new?

Both `t` and `link` sanitize the text resulting in double escaping. Remove the `t()` function. Could be a problem if someone is actually using this `t()` but I don't see how that would be possible, since it only contains a variable...

## How should this be tested?

1. Add a compound to an object with a ` in it. See its double escaped (using jail block). 
2. Apply patch, check its no longer double escaped.

## Interested parties
@whikloj @Islandora/7-x-1-x-committers