### PR TITLE
ISLANDORA-2186: Compound title repeats when on parent PID

### DIFF
--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -568,10 +568,17 @@ function islandora_compound_object_menu_local_tasks_alter(&$data, $router_item, 
       $compound_object = menu_get_object('islandora_object', 2);
       $compound_info = islandora_compound_object_retrieve_compound_info($compound_object, TRUE);
       if ($compound_info) {
-        drupal_set_title(t('@parent - @child', array(
-          '@parent' => $compound_info['parent_label'],
-          '@child' => $compound_info['label'],
-        )), PASS_THROUGH);
+        if ($compound_object->id == $compound_info['parent_pid']) {
+          // We are the parent so don't repeat the label twice.
+          drupal_set_title($compound_info['parent_label']);
+        }
+        else {
+          // Display both the parent and child label.
+          drupal_set_title(t('@parent - @child', array(
+            '@parent' => $compound_info['parent_label'],
+            '@child' => $compound_info['label'],
+          )), PASS_THROUGH);
+        }
       }
       if (isset($data['tabs'][0]['output'])) {
         $query_params = drupal_get_query_parameters();


### PR DESCRIPTION
## JIRA Ticket:
https://jira.duraspace.org/browse/ISLANDORA-2186

## What does this Pull Request do?

When visiting a compound object using the JAIL block, when you are displaying the parent object its title repeats twice.

## What's new?

Modify title set code so it doesn't repeat the title twice.

## How should this be tested?

Create a compound with this structure:
* Title: Test Object
   PID: `obj:1`
  * Title: Child 1
     PID: `obj:2`
  * Title: Child 2
     PID: `obj:3`

* Enable the JAIL display
* Without the patch
  * when you are visiting `obj:1` the title of the page will be: Test Object - Test Object
  * when you are visiting `obj:2` the title of the page will be: Test Object - Child 1
  * when you are visiting `obj:3` the title of the page will be: Test Object - Child 2
* With the patch
  * when you are visiting `obj:1` the title of the page will be: Test Object 
  * when you are visiting `obj:2` the title of the page will be: Test Object - Child 1
  * when you are visiting `obj:3` the title of the page will be: Test Object - Child 2

## Interested parties
@Islandora/7-x-1-x-committers @DiegoPino 