### PR TITLE
Don't create orphans when deleting compound

### DIFF
--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -1,4 +1,8 @@
 <?php
+/**
+ * @file
+ * Batch functionality for the compound solution pack.
+ */
 
 /**
  * Creates batch object for deleting the children of a compound.
@@ -7,6 +11,7 @@
  *   The compound we are deleting from.
  * @param array $children
  *   An array of children to delete.
+ *
  * @return array
  *   The batch array to be passed to batch_set.
  */
@@ -45,6 +50,7 @@ function islandora_compound_object_delete_children_batch(AbstractObject $compoun
  *   The children of the compound being deleted.
  * @param array $context
  *   The batch context.
+ *
  * @return mixed
  *   The child being processed in this invocation.
  */
@@ -52,19 +58,25 @@ function islandora_compound_object_start_operation(AbstractObject $compound, arr
   if (!isset($context['sandbox']['progress'])) {
     $context['sandbox']['progress'] = 0;
     $context['sandbox']['total'] = count($children);
-    $context['results'] = array('deleted' => 0, 'removed' => 0, 'parent' => $compound->label);
+    $context['results'] = array(
+      'deleted' => 0,
+      'removed' => 0,
+      'parent' => $compound->label
+    );
   }
   return $children[$context['sandbox']['progress']];
 }
 
 /**
- * Check if an object has other parents. Assumes that the parents relationship belongs to
- * FEDORA_RELS_EXT_URI namespace.
+ * Check if an object has other parents.
+ *
+ * Assumes that the parents relationship belongs to FEDORA_RELS_EXT_URI namespace.
  *
  * @param AbstractObject $child
  *   The child object.
  * @param AbstractObject $compound
  *   The parent compound.
+ *
  * @return bool
  *   TRUE if the child has other parents, FALSE otherwise.
  */
@@ -143,11 +155,11 @@ function islandora_compound_object_delete_children_batch_operation(AbstractObjec
 /**
  * Called when the batch is finished. Sets a success/fail message.
  *
- * @param $success
+ * @param bool $success
  *   Success of the batch.
- * @param $results
+ * @param array $results
  *   Results from the batch context.
- * @param $operations
+ * @param array $operations
  *   Operations in the batch.
  */
 function islandora_compound_object_batch_finished($success, $results, $operations) {

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -1,0 +1,180 @@
+<?php
+
+/**
+ * Creates batch object for deleting the children of a compound.
+ *
+ * @param AbstractObject $compound
+ *   The compound we are deleting from.
+ * @param array $children
+ *   An array of children to delete.
+ * @return array
+ *   The batch array to be passed to batch_set.
+ */
+function islandora_compound_object_delete_children_batch(AbstractObject $compound, array $children) {
+  $batch = array(
+    'finished' => 'islandora_compound_object_batch_finished',
+    'progress_message' => t('Time elapsed: @elapsed <br/>Estimated time remaining @estimate.'),
+    'error_message' => t('An error has occurred.'),
+    'file' => drupal_get_path('module', 'islandora_compound_object') . '/includes/batch.inc',
+  );
+  $message_parameters = array('@compound' => $compound->label);
+  $child_count = count($children);
+  $batch += array(
+    'operations' => array(
+      array(
+        'islandora_compound_object_delete_children_batch_operation',
+        array($compound, $children),
+      ),
+    ),
+    'title' => format_plural($child_count,
+      'Deleting 1 child from @compound ...',
+      'Deleting @count children from @compound ...', $message_parameters),
+    'init_message' => format_plural($child_count,
+      'Preparing to delete 1 child from @compound ...',
+      'Preparing to delete @count children from @compound ...', $message_parameters),
+  );
+  return $batch;
+}
+
+/**
+ * Starts the batch operation.
+ *
+ * @param AbstractObject $compound
+ *   The compound being deleted.
+ * @param array $children
+ *   The children of the compound being deleted.
+ * @param array $context
+ *   The batch context.
+ * @return mixed
+ *   The child being processed in this invocation.
+ */
+function islandora_compound_object_start_operation(AbstractObject $compound, array $children, array &$context) {
+  if (!isset($context['sandbox']['progress'])) {
+    $context['sandbox']['progress'] = 0;
+    $context['sandbox']['total'] = count($children);
+    $context['results'] = array('deleted' => 0, 'removed' => 0, 'parent' => $compound->label);
+  }
+  return $children[$context['sandbox']['progress']];
+}
+
+/**
+ * Check if an object has other parents. Assumes that the parents relationship belongs to
+ * FEDORA_RELS_EXT_URI namespace.
+ *
+ * @param AbstractObject $child
+ *   The child object.
+ * @param AbstractObject $compound
+ *   The parent compound.
+ * @return bool
+ *   TRUE if the child has other parents, FALSE otherwise.
+ */
+function islandora_compound_object_has_other_parents(AbstractObject $child, AbstractObject $compound) {
+  $relationships = $child->relationships->get(FEDORA_RELS_EXT_URI);
+  foreach ($relationships as $relationship) {
+    if ($relationship['object']['literal'] == FALSE && $relationship['object']['value'] != $compound->id) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+/**
+ * Removes the compound relationships from the child.
+ *
+ * @param AbstractObject $child
+ *   The child object.
+ * @param AbstractObject $compound
+ *   The parent object.
+ */
+function islandora_compound_remove_relationships(AbstractObject $child, AbstractObject $compound) {
+  $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
+  $escaped_pid = str_replace(':', '_', $compound->id);
+  $child->relationships->autoCommit = FALSE;
+  $child->relationships->remove(FEDORA_RELS_EXT_URI, $rels_predicate, $compound->id);
+  $child->relationships->remove(ISLANDORA_RELS_EXT_URI, "isSequenceNumberOf$escaped_pid");
+  $child->relationships->commitRelationships();
+}
+
+/**
+ * Moves the progress of the batch operation. Ending if appropriate.
+ *
+ * @param array $context
+ *   The batch context.
+ */
+function islandora_compound_object_end_operation(array &$context) {
+  $context['sandbox']['progress']++;
+  if ($context['sandbox']['progress'] < $context['sandbox']['total']) {
+    $context['finished'] = $context['sandbox']['progress'] / $context['sandbox']['total'];
+  }
+  else {
+    $context['finished'] = 1;
+  }
+}
+
+/**
+ * The batch operation to remove the children.
+ *
+ * Removes their relationships to the parent if they have other parents, and deletes them otherwise.
+ *
+ * @param AbstractObject $compound
+ *   The parent compound.
+ * @param array $children
+ *   The list of children being processed.
+ * @param array $context
+ *   The batch context.
+ */
+function islandora_compound_object_delete_children_batch_operation(AbstractObject $compound, array $children, array &$context) {
+  $child = islandora_compound_object_start_operation($compound, $children, $context);
+  if ($child && $child = islandora_object_load($child)) {
+    if (islandora_compound_object_has_other_parents($child, $compound)) {
+      // If more than one parent, only remove parent relationship.
+      islandora_compound_remove_relationships($child, $compound);
+      $context['results']['removed']++;
+    }
+    else {
+      // If only one parent, delete the object.
+      islandora_delete_object($child);
+      $context['results']['deleted']++;
+    }
+  }
+  islandora_compound_object_end_operation($context);
+}
+
+/**
+ * Called when the batch is finished. Sets a success/fail message.
+ *
+ * @param $success
+ *   Success of the batch.
+ * @param $results
+ *   Results from the batch context.
+ * @param $operations
+ *   Operations in the batch.
+ */
+function islandora_compound_object_batch_finished($success, $results, $operations) {
+  if ($success) {
+    $deleted = format_plural($results['deleted'],
+      'Deleted 1 child from @compound.',
+      'Deleted @count children from @compound.',
+      array('@compound' => $results['parent'])
+    );
+    $removed = format_plural($results['removed'],
+      'Removed 1 child from @compound.',
+      'Removed @count children from @compound.',
+      array('@compound' => $results['parent'])
+    );
+    if ($results['deleted']) {
+      drupal_set_message($deleted);
+    }
+    if ($results['removed']) {
+      drupal_set_message($removed);
+    }
+  }
+  else {
+    // Generic Error Message.
+    $error_operation = reset($operations);
+    $message = t('An error occurred while processing %error_operation with arguments: @arguments', array(
+      '%error_operation' => $error_operation[0],
+      '@arguments' => print_r($error_operation[1], TRUE)));
+    drupal_set_message($message, 'error');
+  }
+}

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -61,7 +61,7 @@ function islandora_compound_object_start_operation(AbstractObject $compound, arr
     $context['results'] = array(
       'deleted' => 0,
       'removed' => 0,
-      'parent' => $compound->label
+      'parent' => $compound->label,
     );
   }
   return $children[$context['sandbox']['progress']];
@@ -70,7 +70,7 @@ function islandora_compound_object_start_operation(AbstractObject $compound, arr
 /**
  * Check if an object has other parents.
  *
- * Assumes that the parents relationship belongs to FEDORA_RELS_EXT_URI namespace.
+ * Assumes that parents relationship belongs to FEDORA_RELS_EXT_URI namespace.
  *
  * @param AbstractObject $child
  *   The child object.
@@ -126,7 +126,8 @@ function islandora_compound_object_end_operation(array &$context) {
 /**
  * The batch operation to remove the children.
  *
- * Removes their relationships to the parent if they have other parents, and deletes them otherwise.
+ * Removes their relationships to the parent if they have other parents, and
+ * deletes them otherwise.
  *
  * @param AbstractObject $compound
  *   The parent compound.

--- a/includes/batch.inc
+++ b/includes/batch.inc
@@ -70,7 +70,8 @@ function islandora_compound_object_start_operation(AbstractObject $compound, arr
 /**
  * Check if an object has other parents.
  *
- * Assumes that parents relationship belongs to FEDORA_RELS_EXT_URI namespace.
+ * Will return true if object has any relationship to anther object other then
+ * its content model object.
  *
  * @param AbstractObject $child
  *   The child object.
@@ -81,9 +82,14 @@ function islandora_compound_object_start_operation(AbstractObject $compound, arr
  *   TRUE if the child has other parents, FALSE otherwise.
  */
 function islandora_compound_object_has_other_parents(AbstractObject $child, AbstractObject $compound) {
-  $relationships = $child->relationships->get(FEDORA_RELS_EXT_URI);
+  $relationships = $child->relationships->get();
   foreach ($relationships as $relationship) {
-    if ($relationship['object']['literal'] == FALSE && $relationship['object']['value'] != $compound->id) {
+    $is_cmodel_relationship = $relationship['predicate']['namespace'] == FEDORA_MODEL_URI
+      && $relationship['predicate']['value'] == 'hasModel';
+    if (!$is_cmodel_relationship
+      && $relationship['object']['literal'] == FALSE
+      && $relationship['object']['value'] != $compound->id
+    ) {
       return TRUE;
     }
   }

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -157,17 +157,43 @@ function islandora_compound_object_block_view($delta = '') {
 }
 
 /**
- * Implements hook_CMODEL_PID_islandora_object_purged().
+ * Implements hook_form_FORM_ID_alter().
  */
-function islandora_compound_object_islandora_compoundcmodel_islandora_object_purged($pid) {
-  $parts = islandora_compound_object_get_parts($pid);
-  $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
-  foreach ($parts as $part) {
-    $escaped_pid = str_replace(':', '_', $pid);
-    $child_object = islandora_object_load($part);
-    $child_object->relationships->remove(FEDORA_RELS_EXT_URI, $rels_predicate, $pid);
-    $child_object->relationships->remove(ISLANDORA_RELS_EXT_URI, "isSequenceNumberOf$escaped_pid");
+function islandora_compound_object_form_islandora_object_properties_form_alter(array &$form, array &$form_state) {
+  $object = $form_state['object'];
+  if (in_array(ISLANDORA_COMPOUND_OBJECT_CMODEL, $object->models)) {
+    $form['delete']['#value'] = t('Delete Compound Object');
   }
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function islandora_compound_object_form_islandora_delete_object_form_alter(array &$form, array &$form_state) {
+  $object = $form_state['object'];
+  if (in_array(ISLANDORA_COMPOUND_OBJECT_CMODEL, $object->models)) {
+    $form['description']['#markup'] = t('This will remove the compound object and all its child objects. Child objects currently shared with collections or part of other compound objects will not be deleted. This action cannot be undone.');
+    $form['#submit'] = array('islandora_compound_object_islandora_delete_object_form_delete_children_submit');
+  }
+}
+
+/**
+ * Delete all the child objects related to the compound object object being deleted.
+ *
+ * @param array $form
+ *   The Drupal form.
+ * @param array $form_state
+ *   The Drupal form state.
+ */
+function islandora_compound_object_islandora_delete_object_form_delete_children_submit(array $form, array &$form_state) {
+  module_load_include('inc', 'islandora_compound_object', 'includes/batch');
+  $object = $form_state['object'];
+  batch_set(islandora_compound_object_delete_children_batch($object, islandora_compound_object_get_parts($object->id)));
+  // Called from within this submit handler rather than from the Drupal Form API
+  // as we need the object to exist to generate the pages and if we run this
+  // batch operation from a submit handler any submit handlers to be called
+  // afterwards will not get called, which is a bug/feature of the Form API.
+  islandora_delete_object_form_submit($form, $form_state);
 }
 
 /**
@@ -767,3 +793,4 @@ function islandora_compound_object_islandora_compound_object_query_backends() {
     ),
   );
 }
+

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -178,7 +178,7 @@ function islandora_compound_object_form_islandora_delete_object_form_alter(array
 }
 
 /**
- * Delete all the child objects related to the compound object object being deleted.
+ * Delete all the child objects related to the compound object being deleted.
  *
  * @param array $form
  *   The Drupal form.
@@ -793,4 +793,3 @@ function islandora_compound_object_islandora_compound_object_query_backends() {
     ),
   );
 }
-


### PR DESCRIPTION
## JIRA Ticket:
https://jira.duraspace.org/browse/ISLANDORA-2294

This solution was discussed in the committers meeting yesterday.

## What does this Pull Request do?

Currently when deleting a compound we just remove relationships from children, so they are parentless and hard to detect. This PR changes that so that when deleting a compound we check if the children have parents. If they do we remove the relationships, otherwise we delete the children.

## What's new?

This updates compound deletes to work more like books and collections. It runs a batch that deletes the items or removes the relationships if they have other parents.

## How should this be tested?

I think the most important part of this PR is making sure that the other parent detection works correctly. We don't want to delete objects that have other parents. 

Some test cases: 
- Add a compound
- Batch import objects into compound (won't have other parents) 
- Add a book
- Add book pages
- Add a book page to the compound
- Add a item to the collection
- Add the item in the collection to the compound
- Add a newspaper, add an issue, add a page
- Add the issue and page to the compound
- Delete the compound and make sure that the correct objects are deleted and for the others the relationships are removed.

## Interested parties
@DiegoPino @Islandora/7-x-1-x-committers