### PR TITLE
Make admin page allow tabs

### DIFF
--- a/islandora_compound_object.install
+++ b/islandora_compound_object.install
@@ -35,3 +35,13 @@ function islandora_compound_object_uninstall() {
   );
   array_walk($variables, 'variable_del');
 }
+
+/**
+ * Update compound backend name.
+ */
+function islandora_compound_update_7001() {
+  $backend = variable_get('islandora_compound_object_query_backend', ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND);
+  if ($backend == 'islandora_basic_collection_sparql_query_backend') {
+    variable_set('islandora_compound_object_query_backend', ISLANDORA_COMPOUND_OBJECT_SPARQL_BACKEND);
+  }
+}

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -11,6 +11,7 @@
 define('ISLANDORA_COMPOUND_OBJECT_CMODEL', 'islandora:compoundCModel');
 
 const ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND = 'islandora_compound_object_legacy_sparql';
+const ISLANDORA_COMPOUND_OBJECT_SPARQL_BACKEND = 'islandora_compound_object_sparql_query_backend';
 
 /**
  * Implements hook_menu().
@@ -786,7 +787,7 @@ function islandora_compound_object_islandora_compound_object_query_backends() {
       'callable' => 'islandora_compound_object_legacy_query_sparql',
       'file' => "$module_path/includes/backends.inc",
     ),
-    'islandora_basic_collection_sparql_query_backend' => array(
+    ISLANDORA_COMPOUND_OBJECT_SPARQL_BACKEND => array(
       'title' => t('SPARQL - Does a SPARQL query with filters. Generally faster than the default option.'),
       'callable' => 'islandora_compound_object_query_sparql',
       'file' => "$module_path/includes/backends.inc",

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -26,6 +26,15 @@ function islandora_compound_object_menu() {
     'file' => 'includes/admin.form.inc',
     'type' => MENU_NORMAL_ITEM,
   );
+  $items['admin/islandora/solution_pack_config/compound_object/settings'] = array(
+    'title' => 'Settings',
+    'description' => 'Customize behavior.',
+    'access arguments' => array('administer compound relationships'),
+    'page callback' => 'drupal_get_form',
+    'page arguments' => array('islandora_compound_object_admin_form'),
+    'file' => 'includes/admin.form.inc',
+    'type' => MENU_DEFAULT_LOCAL_TASK,
+  );
   $items['islandora/object/%islandora_object/manage/compound'] = array(
     'title' => 'Compound',
     'page callback' => 'islandora_compound_object_manage',


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2272

Related to: https://github.com/Islandora/islandora_solr_search/pull/347

# What does this Pull Request do?

Just makes it so the related PR can add its own configuration tab.

# What's new?

Makes the default settings a tab.

# How should this be tested?

Should have no functional difference except you will see the Solution pack admin is now on a tab called Settings.

# Additional Notes:

Example:
* Does this change require documentation to be updated? no
* Does this change add any new dependencies? no
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
* Could this change impact execution of existing code? no

# Interested parties
@Islandora/7-x-1-x-committers
