### PR TITLE
ISLANDORA-2059

### DIFF
--- a/includes/backends.inc
+++ b/includes/backends.inc
@@ -65,6 +65,20 @@ EOQ;
  * Implements callback_islandora_compound_object_query_backends().
  */
 function islandora_compound_object_query_sparql($pid) {
+  return islandora_compound_object_query_sparql_general($pid, FALSE);
+}
+
+/**
+ * Implements callback_islandora_compound_object_query_backends().
+ */
+function islandora_compound_object_query_sparql_compliant($pid) {
+  return islandora_compound_object_query_sparql_general($pid, TRUE);
+}
+
+/**
+ * General callback function for SPARQL query functions above.
+ */
+function islandora_compound_object_query_sparql_general($pid, $cast_int = FALSE) {
   module_load_include('inc', 'islandora', 'includes/utilities');
 
   $rels_predicate = variable_get('islandora_compound_object_relationship', 'isConstituentOf');
@@ -95,6 +109,20 @@ function islandora_compound_object_query_sparql($pid) {
   }
 
   $escaped_pid = str_replace(':', '_', $pid);
+
+  // XXX: The default Mulgara triple store sorts the sequence number as an
+  // integer, even though it doesn't have the integer type. Other SPARQL
+  // compliant triple stores (specifically blazegraph) may do a string sort
+  // on this, leading to the results being sorted strangely. Mulgara doesn't
+  // support casting datatypes, but any SPARQL compatible store should. This
+  // lets compatible stores return the results in the int sort order.
+  if ($cast_int) {
+    $sort = 'ORDER BY ASC(xsd:integer(?seq))';
+  }
+  else {
+    $sort = 'ORDER BY ASC(?seq)';
+  }
+
   $query = <<<EOQ
 PREFIX islandora-rels-ext: <http://islandora.ca/ontology/relsext#>
 SELECT DISTINCT ?object ?title ?seq
@@ -113,7 +141,7 @@ WHERE {
   FILTER((!bound(?role) && !bound(?user)) || (bound(?user) && ?user='{$user_name}') || (bound(?role) && ($role_matcher)))
   $namespace_filter
 }
-ORDER BY ASC(?seq)
+$sort
 EOQ;
 
   $connection = islandora_get_tuque_connection();

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -12,6 +12,7 @@ define('ISLANDORA_COMPOUND_OBJECT_CMODEL', 'islandora:compoundCModel');
 
 const ISLANDORA_COMPOUND_OBJECT_LEGACY_BACKEND = 'islandora_compound_object_legacy_sparql';
 const ISLANDORA_COMPOUND_OBJECT_SPARQL_BACKEND = 'islandora_compound_object_sparql_query_backend';
+const ISLANDORA_COMPOUND_OBJECT_SPARQL_COMPLIANT_BACKEND = 'islandora_compound_object_sparql_query_compliant_backend';
 
 /**
  * Implements hook_menu().
@@ -801,7 +802,7 @@ function islandora_compound_object_islandora_compound_object_query_backends() {
       'callable' => 'islandora_compound_object_query_sparql',
       'file' => "$module_path/includes/backends.inc",
     ),
-    'islandora_basic_collection_sparql_query_backend_compliant' => array(
+    ISLANDORA_COMPOUND_OBJECT_SPARQL_COMPLIANT_BACKEND => array(
       'title' => t('SPARQL - Use this option for fully compliant SPARQL triple stores. Does not work with Mulgara.'),
       'callable' => 'islandora_compound_object_query_sparql_compliant',
       'file' => "$module_path/includes/backends.inc",

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -801,6 +801,11 @@ function islandora_compound_object_islandora_compound_object_query_backends() {
       'callable' => 'islandora_compound_object_query_sparql',
       'file' => "$module_path/includes/backends.inc",
     ),
+    'islandora_basic_collection_sparql_query_backend_compliant' => array(
+      'title' => t('SPARQL - Use this option for fully compliant SPARQL triple stores. Does not work with Mulgara.'),
+      'callable' => 'islandora_compound_object_query_sparql_compliant',
+      'file' => "$module_path/includes/backends.inc",
+    ),
   );
 }
 


### PR DESCRIPTION
## JIRA Ticket

Main JIRA ticket: 
https://jira.duraspace.org/browse/ISLANDORA-2059

Dupe JIRA ticket: 
https://jira.duraspace.org/browse/ISLANDORA-2072

This PR is a follow up from https://github.com/Islandora/islandora_solution_pack_compound/pull/134 where there is a lot of good discussion on this issue.

## What does this Pull Request do?

Ensure there is a way to have Blazegraph backed repositories return compounds in the correct order.

## What's new?

This PR adds a new query backend that is 99% the same, but casts the sequence number to an integer so that Blazegraph (and potentially other triple stores) return the correct sort order. This is *not* compatible with the default Mulgara triple store.

## How should this be tested?

### Notes
You can't test this with Mulgara, but can test if you have another triple store backing your repository. 

### Instructions
Create a compound with more than 10 objects, for example 12 objects.  You should see them appearing in the wrong order in the UI. In the compound solution pack options pick: *SPARQL - Use this option for fully compliant SPARQL triple stores. Does not work with Mulgara.*. Now you should be seeing the compound returned in the correct order.

### Example
1
10
11
12
2
3

## Interested parties
@whikloj @DiegoPino @Islandora/7-x-1-x-committers