### PR TITLE
Add self-transform to default form association

### DIFF
--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -276,6 +276,7 @@ function islandora_compound_object_xml_form_builder_form_associations() {
       'dsid' => 'MODS',
       'title_field' => array('titleInfo', 'title'),
       'transform' => 'mods_to_dc.xsl',
+      'self_transform' => 'islandora_cleanup_mods_extended.xsl',
       'template' => FALSE,
     ),
   );


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2383)

# What does this Pull Request do?

Adds cleanup self-transform to the Compound Object SP default form association. Provides a cleaner MODS xml datastream.

This is/will be one of many similar updates, as all of the stock forms should receive this association.

# How should this be tested?
* Ingest a test object with lots of blank fields in the form; review the resulting MODS XML and see how it is filled with a horrible mass of empty XML elements
* Check out the branch
* Review the form association (form builder -> enabled associations)
* Ingest a test object with a lot of blank metadata fields and review the resulting MODS XML, see how it's less horrible than before

# Interested parties
@Islandora/7-x-1-x-committers