### PR TITLE
Error during Batch Ingests of Compound Children before parent objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,19 @@ matrix:
     - php: 5.3.3
       dist: precise
       env: FEDORA_VERSION="3.8.1"
+  allow_failures:
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.5"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.6.2"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.7.0"
+    - php: 5.3.3
+      dist: precise
+      env: FEDORA_VERSION="3.8.1"
 php:
   - 5.4
   - 5.5

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -745,11 +745,10 @@ function islandora_compound_object_retrieve_compound_info(AbstractObject $object
     }
     else {
       $parent_url = FALSE;
-      $parent = (object) array('label' => NULL);
     }
 
     $info = array(
-      'parent_label' => $parent->label,
+      'parent_label' => ($parent && $parent->label) ? $parent->label : NULL,
       'parent_pid' => $parent_pid,
       'parent_url' => $parent_url,
       'previous_pid' => $previous_pid,

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -719,7 +719,9 @@ function islandora_compound_object_retrieve_compound_info(AbstractObject $object
     // For now just grab the last value in the array.
     $part = array_pop($part_of);
     $parent_pid = $part['object']['value'];
-    $parent = islandora_object_load($parent_pid);
+    if (!$parent = islandora_object_load($parent_pid)) {
+      $parent = NULL;
+    }
   }
   // Assume this object is the parent compound object.
   else {

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -719,9 +719,7 @@ function islandora_compound_object_retrieve_compound_info(AbstractObject $object
     // For now just grab the last value in the array.
     $part = array_pop($part_of);
     $parent_pid = $part['object']['value'];
-    if (!$parent = islandora_object_load($parent_pid)) {
-      return array();
-    }
+    $parent = islandora_object_load($parent_pid);
   }
   // Assume this object is the parent compound object.
   else {
@@ -741,12 +739,13 @@ function islandora_compound_object_retrieve_compound_info(AbstractObject $object
     $next_pid = (isset($siblings[$current_key + 1])) ? $siblings[$current_key + 1] : '';
 
     // Check if perms to show link for parent manage.
-    if (islandora_object_manage_access_callback(array(
+    if ($parent && islandora_object_manage_access_callback(array(
       ISLANDORA_METADATA_EDIT, ISLANDORA_MANAGE_PROPERTIES, ISLANDORA_ADD_DS), $parent)) {
       $parent_url = 'islandora/object/' . $parent_pid . '/manage';
     }
     else {
       $parent_url = FALSE;
+      $parent = (object) array('label' => NULL);
     }
 
     $info = array(

--- a/islandora_compound_object.module
+++ b/islandora_compound_object.module
@@ -720,7 +720,7 @@ function islandora_compound_object_retrieve_compound_info(AbstractObject $object
     $part = array_pop($part_of);
     $parent_pid = $part['object']['value'];
     if (!$parent = islandora_object_load($parent_pid)) {
-      $parent = NULL;
+      return array();
     }
   }
   // Assume this object is the parent compound object.


### PR DESCRIPTION
**ISLANDORA-2418**: (https://jira.duraspace.org/browse/ISLANDORA-2418)


# What does this Pull Request do?
This pull request will prevent the following PHP error caused when information about a compound child is requested using "islandora_compound_object_retrieve_compound_info".
`Argument 2 passed to islandora_object_manage_access_callback() must be an instance of AbstractObject, boolean given, called in /var/www/drupal7/sites/all/modules/islandora_solution_pack_compound/islandora_compound_object.module on line 743 and defined in islandora_object_manage_access_callback() (line 930 of /var/www/drupal7/sites/all/modules/islandora/islandora.module).`

This error can cause issues during batch ingests, where derivative generation is deferred and controlled by a third party tool such as Gearman. It was observed that this error prevented some servers from removing temporary files created during derivative generation.

This issue was brought up as a result of a recent change in the Islandora module. Commit a46936cf7b5fae9002b34c81f180509ce5af8744
Found here: https://github.com/Islandora/islandora/commit/a46936cf7b5fae9002b34c81f180509ce5af8744#diff-ab8875f550771e37425e399a32097fb0R930

# What's new?
* The PR checks if the parent object is loaded
* If not, creates a standard object with NULL values to be used in the information array returned by the function.

# How should this be tested?
--- Before merging code ---
* Create a batch ingest that creates at least one child compound object with a parent that does not exist. 
** A module like the Islandora Spreadsheet Ingest module can be used.
* Once ingested, navigate to the object and the PHP error, "Argument 2 passed to islandora_object_manage_access_callback() must be an instance of AbstractObject..." should be produced.

--- After merging the code from this PR ---
* The error will not be seen and the object should load with no issues.

# Additional Notes:
Note that when derivatives are deferred and a third party tool is used to generate derivatives, the PHP thread can die. This can lead to the system not removing temporary files created during derivative generation. Below is a sample of this error observed using Gearman
`Apr  3 06:20:18 ingest gearman-worker.sh[14024]: WD php: TypeError: Argument 2 passed to                                  [error]
Apr  3 06:20:18 ingest gearman-worker.sh[14024]: islandora_object_manage_access_callback() must be an instance of
Apr  3 06:20:18 ingest gearman-worker.sh[14024]: AbstractObject or null, boolean given, called in
Apr  3 06:20:18 ingest gearman-worker.sh[14024]: /var/www/drupal7/sites/all/modules/islandora_solution_pack_compound/islandora_compound_object.module
Apr  3 06:20:18 ingest gearman-worker.sh[14024]: on line 742 in islandora_object_manage_access_callback() (line 930 of
Apr  3 06:20:18 ingest gearman-worker.sh[14024]: /var/www/drupal7/sites/all/modules/islandora/islandora.module).
Apr  3 06:20:18 ingest gearman-worker.sh[14024]: Drush command terminated abnormally due to an unrecoverable error.       [error]
Apr  3 06:20:18 ingest gearman-worker.sh[14024]: gearman: gearman_worker_work : GEARMAN_UNKNOWN_STATE`

# Interested parties
@Islandora/7-x-1-x-committers
@DiegoPino 
@jordandukart 
